### PR TITLE
Back Button Fixed AdminActivity

### DIFF
--- a/AndroidApp/UBCollecting/app/src/main/java/edu/buffalo/cse/ubcollecting/ui/LoginActivity.java
+++ b/AndroidApp/UBCollecting/app/src/main/java/edu/buffalo/cse/ubcollecting/ui/LoginActivity.java
@@ -85,6 +85,7 @@ public class LoginActivity extends AppCompatActivity {
                         i = UserLandingActivity.newIntent(LoginActivity.this);
                     }
                     startActivity(i);
+                    finish();
                 }
             }
         });


### PR DESCRIPTION
When on the AdminActivity page, if you press the back button it will log you out of the app instead of taking you to the login screen.