### PR TITLE
Fixed Questions Causing Crashes

### DIFF
--- a/AndroidApp/UBCollecting/app/src/main/java/edu/buffalo/cse/ubcollecting/ui/interviewer/AudioFragment.java
+++ b/AndroidApp/UBCollecting/app/src/main/java/edu/buffalo/cse/ubcollecting/ui/interviewer/AudioFragment.java
@@ -177,8 +177,8 @@ public class AudioFragment extends QuestionFragment{
     protected boolean validateEntry() {
         boolean valid = true;
 
-        if (mCurrentPath.isEmpty()){
-            Toast.makeText(this.getActivity(), "Please Fill in All Required Fields", Toast.LENGTH_SHORT).show();
+        if (mCurrentPath == null || mCurrentPath.isEmpty()){
+            Toast.makeText(this.getActivity(), "Please Record an Audio Snippet", Toast.LENGTH_SHORT).show();
             valid = false;
         }
 

--- a/AndroidApp/UBCollecting/app/src/main/java/edu/buffalo/cse/ubcollecting/ui/interviewer/PhotoFragment.java
+++ b/AndroidApp/UBCollecting/app/src/main/java/edu/buffalo/cse/ubcollecting/ui/interviewer/PhotoFragment.java
@@ -180,7 +180,7 @@ public class PhotoFragment extends QuestionFragment {
 
         boolean valid = true;
 
-        if (mCurrentPath.isEmpty()){
+        if (mCurrentPath == null || mCurrentPath.isEmpty()){
             Toast.makeText(this.getActivity(), "Please Take a Photo", Toast.LENGTH_SHORT).show();
             valid = false;
         }

--- a/AndroidApp/UBCollecting/app/src/main/java/edu/buffalo/cse/ubcollecting/ui/interviewer/VideoFragment.java
+++ b/AndroidApp/UBCollecting/app/src/main/java/edu/buffalo/cse/ubcollecting/ui/interviewer/VideoFragment.java
@@ -182,7 +182,7 @@ public class VideoFragment extends QuestionFragment{
 
         boolean valid = true;
 
-        if (mCurrentPath.isEmpty()){
+        if (mCurrentPath == null || mCurrentPath.isEmpty()){
             Toast.makeText(this.getActivity(), "Please Take a Video", Toast.LENGTH_SHORT).show();
             valid = false;
         }


### PR DESCRIPTION
Fixed Questions that caused crashes. The checks were not checking for the mCurrentPath to be null. Issue #22 